### PR TITLE
fix(memory): stabilize observation ordering

### DIFF
--- a/Scripts/BackendTests/Memory/MemoryPersistenceBehavior.test.ts
+++ b/Scripts/BackendTests/Memory/MemoryPersistenceBehavior.test.ts
@@ -114,15 +114,19 @@ describe("Memory persistence behavior", () => {
           confidence: 0.9,
           tags: ["release", "preview"],
           triggers: ["deploy"],
-          writtenAt: "2026-01-02T00:01:00.000Z",
+        }),
+      );
+      const updated = repository.writeDirectMemory(
+        directWrite("update", {
+          targetMemoryUri: initial.uri,
+          claim: "Use verified preview releases first",
         }),
       );
       const replacement = repository.writeDirectMemory(
         directWrite("supersede", {
-          targetMemoryUri: initial.uri,
+          targetMemoryUri: updated.uri,
           claim: "Promote verified previews without rebuilding",
           confidence: 0.95,
-          writtenAt: "2026-01-02T00:02:00.000Z",
         }),
       );
       repository.upsertMemoryItemVectors([
@@ -140,9 +144,12 @@ describe("Memory persistence behavior", () => {
       expect(repository.listActiveMemoryItems()).toEqual([
         expect.objectContaining({ uri: replacement.uri, claim: "Promote verified previews without rebuilding" }),
       ]);
-      expect(repository.listMemoryObservations(initial.uri).map((entry) => entry.operation)).toEqual([
-        "create",
-        "reinforce",
+      expect(
+        repository.listMemoryObservations(initial.uri).map((entry) => [entry.writeSequence, entry.operation]),
+      ).toEqual([
+        [1, "create"],
+        [2, "reinforce"],
+        [3, "update"],
       ]);
       expect(repository.listMemoryItemVectors("test-embedding")).toEqual([
         expect.objectContaining({ memoryUri: replacement.uri, embedding: [0.1, 0.9] }),
@@ -259,7 +266,10 @@ function learningAction(
   };
 }
 
-function directWrite(operation: "create" | "reinforce" | "supersede", overrides: Record<string, unknown> = {}) {
+function directWrite(
+  operation: "create" | "reinforce" | "update" | "supersede",
+  overrides: Record<string, unknown> = {},
+) {
   return {
     operation,
     type: "preference" as const,

--- a/Source/AgentSystem/Memory/AgentMemoryInMemorySourceRepository.ts
+++ b/Source/AgentSystem/Memory/AgentMemoryInMemorySourceRepository.ts
@@ -26,6 +26,7 @@ import type {
   AgentMemoryItemRecord,
   AgentMemoryItemVectorRecord,
   AgentMemoryItemVectorWrite,
+  AgentMemoryLearningActionRecord,
   AgentMemoryLearningWriteInput,
   AgentMemoryLearningJobRecord,
   AgentMemoryObservationRecord,
@@ -42,6 +43,7 @@ export class InMemoryAgentMemorySourceRepository implements AgentMemorySourceRep
   private readonly vectors = new Map<string, AgentMemoryItemVectorRecord>();
   private readonly items = new Map<string, AgentMemoryItemRecord>();
   private readonly observations = new Map<string, AgentMemoryObservationRecord>();
+  private readonly observationWriteSequences = new Map<string, number>();
   private readonly learningJobs = new Map<string, AgentMemoryLearningJobRecord>();
 
   recordCompletedTurn(input: AgentMemoryCompletedTurnInput): AgentMemoryRecordedTurn {
@@ -75,7 +77,7 @@ export class InMemoryAgentMemorySourceRepository implements AgentMemorySourceRep
         const item = buildReinforcedMemoryItem(input.episode, current, action, learnedAt);
         this.items.set(item.uri, item);
         this.markCandidatesPromoted(action.candidateUris, item.uri, learnedAt);
-        this.recordObservation(buildMemoryObservation(input.episode, item.uri, action, learnedAt));
+        this.recordObservation(this.createMemoryObservation(input.episode, item.uri, action, learnedAt));
         written.push(item);
         continue;
       }
@@ -85,7 +87,7 @@ export class InMemoryAgentMemorySourceRepository implements AgentMemorySourceRep
         const item = buildUpdatedMemoryItem(input.episode, current, action, learnedAt);
         this.items.set(item.uri, item);
         this.markCandidatesPromoted(action.candidateUris, item.uri, learnedAt);
-        this.recordObservation(buildMemoryObservation(input.episode, item.uri, action, learnedAt));
+        this.recordObservation(this.createMemoryObservation(input.episode, item.uri, action, learnedAt));
         written.push(item);
         continue;
       }
@@ -107,7 +109,7 @@ export class InMemoryAgentMemorySourceRepository implements AgentMemorySourceRep
       const item = buildNewMemoryItem(input.episode, action, learnedAt);
       this.items.set(item.uri, item);
       this.markCandidatesPromoted(action.candidateUris, item.uri, learnedAt);
-      this.recordObservation(buildMemoryObservation(input.episode, item.uri, action, learnedAt));
+      this.recordObservation(this.createMemoryObservation(input.episode, item.uri, action, learnedAt));
       written.push(item);
     }
     return written;
@@ -123,7 +125,7 @@ export class InMemoryAgentMemorySourceRepository implements AgentMemorySourceRep
       const current = this.readExistingMemory(action.targetMemoryUri);
       const item = buildReinforcedMemoryItem(anchor, current, action, writtenAt);
       this.items.set(item.uri, item);
-      this.recordObservation(buildMemoryObservation(anchor, item.uri, action, writtenAt));
+      this.recordObservation(this.createMemoryObservation(anchor, item.uri, action, writtenAt));
       return item;
     }
 
@@ -131,7 +133,7 @@ export class InMemoryAgentMemorySourceRepository implements AgentMemorySourceRep
       const current = this.readExistingMemory(action.targetMemoryUri);
       const item = buildUpdatedMemoryItem(anchor, current, action, writtenAt);
       this.items.set(item.uri, item);
-      this.recordObservation(buildMemoryObservation(anchor, item.uri, action, writtenAt));
+      this.recordObservation(this.createMemoryObservation(anchor, item.uri, action, writtenAt));
       return item;
     }
 
@@ -151,7 +153,7 @@ export class InMemoryAgentMemorySourceRepository implements AgentMemorySourceRep
 
     const item = buildNewMemoryItem(anchor, action, writtenAt);
     this.items.set(item.uri, item);
-    this.recordObservation(buildMemoryObservation(anchor, item.uri, action, writtenAt));
+    this.recordObservation(this.createMemoryObservation(anchor, item.uri, action, writtenAt));
     return item;
   }
 
@@ -273,7 +275,7 @@ export class InMemoryAgentMemorySourceRepository implements AgentMemorySourceRep
   listMemoryObservations(memoryUri: string): AgentMemoryObservationRecord[] {
     return [...this.observations.values()]
       .filter((observation) => observation.memoryUri === memoryUri)
-      .sort((left, right) => left.createdAtMs - right.createdAtMs || left.id.localeCompare(right.id));
+      .sort((left, right) => left.createdAtMs - right.createdAtMs || left.writeSequence - right.writeSequence);
   }
 
   upsertMemoryItemVectors(records: readonly AgentMemoryItemVectorWrite[]): void {
@@ -428,6 +430,20 @@ export class InMemoryAgentMemorySourceRepository implements AgentMemorySourceRep
     this.observations.set(record.uri, record);
   }
 
+  private createMemoryObservation(
+    episode: AgentMemoryEpisodeRecord,
+    memoryUri: string,
+    action: AgentMemoryLearningActionRecord,
+    observedAt: string,
+  ): AgentMemoryObservationRecord {
+    const writeSequence = (this.observationWriteSequences.get(memoryUri) ?? 0) + 1;
+    if (!Number.isSafeInteger(writeSequence)) {
+      throw new RangeError(`Memory observation write sequence exceeded the safe integer range for ${memoryUri}.`);
+    }
+    this.observationWriteSequences.set(memoryUri, writeSequence);
+    return buildMemoryObservation(episode, memoryUri, action, observedAt, writeSequence);
+  }
+
   private deleteVectorsForMemory(memoryUri: string): void {
     for (const key of this.vectors.keys()) {
       if (key.startsWith(`${memoryUri}\0`)) {
@@ -442,5 +458,6 @@ export class InMemoryAgentMemorySourceRepository implements AgentMemorySourceRep
         this.observations.delete(observation.uri);
       }
     }
+    this.observationWriteSequences.delete(memoryUri);
   }
 }

--- a/Source/AgentSystem/Memory/AgentMemoryItemRecords.ts
+++ b/Source/AgentSystem/Memory/AgentMemoryItemRecords.ts
@@ -113,6 +113,7 @@ export function buildMemoryObservation(
   memoryUri: string,
   action: AgentMemoryLearningActionRecord,
   observedAt: string,
+  writeSequence: number,
 ): AgentMemoryObservationRecord {
   const id = randomMemoryId("obs");
   const time = projectMemoryTime(observedAt);
@@ -120,6 +121,7 @@ export function buildMemoryObservation(
     id,
     uri: memoryObservationUri(id),
     memoryUri,
+    writeSequence,
     operation: action.operation,
     candidateUris: actionCandidateUris(action),
     sourceRefs: uniqueTrimmed(action.sourceRefs),

--- a/Source/AgentSystem/Memory/AgentMemoryObservationSqlStatements.ts
+++ b/Source/AgentSystem/Memory/AgentMemoryObservationSqlStatements.ts
@@ -4,6 +4,7 @@ import type { MemoryObservationRow } from "./AgentMemorySqlRows.js";
 export interface AgentMemoryObservationSqlStatements {
   insertMemoryObservationStmt: Database.Statement;
   listMemoryObservationsStmt: Database.Statement<[string], MemoryObservationRow>;
+  nextMemoryObservationWriteSequenceStmt: Database.Statement<[string], { next_write_sequence: number }>;
 }
 
 export function prepareAgentMemoryObservationSqlStatements(db: Database.Database): AgentMemoryObservationSqlStatements {
@@ -13,6 +14,7 @@ export function prepareAgentMemoryObservationSqlStatements(db: Database.Database
         id,
         uri,
         memory_uri,
+        write_sequence,
         operation,
         candidate_uris_json,
         source_refs_json,
@@ -32,6 +34,7 @@ export function prepareAgentMemoryObservationSqlStatements(db: Database.Database
         @id,
         @uri,
         @memory_uri,
+        @write_sequence,
         @operation,
         @candidate_uris_json,
         @source_refs_json,
@@ -51,7 +54,12 @@ export function prepareAgentMemoryObservationSqlStatements(db: Database.Database
     listMemoryObservationsStmt: db.prepare<[string], MemoryObservationRow>(`
       SELECT * FROM memory_observations
       WHERE memory_uri = ?
-      ORDER BY created_at_ms ASC, id ASC
+      ORDER BY created_at_ms ASC, write_sequence ASC
+    `),
+    nextMemoryObservationWriteSequenceStmt: db.prepare<[string], { next_write_sequence: number }>(`
+      SELECT COALESCE(MAX(write_sequence), 0) + 1 AS next_write_sequence
+      FROM memory_observations
+      WHERE memory_uri = ?
     `),
   };
 }

--- a/Source/AgentSystem/Memory/AgentMemoryRowDecoders.ts
+++ b/Source/AgentSystem/Memory/AgentMemoryRowDecoders.ts
@@ -147,6 +147,7 @@ export function rowToMemoryObservation(row: MemoryObservationRow): AgentMemoryOb
     id: row.id,
     uri: row.uri,
     memoryUri: row.memory_uri,
+    writeSequence: row.write_sequence,
     operation: row.operation,
     candidateUris: parseMemoryRowStringArray(row.candidate_uris_json),
     sourceRefs: parseMemoryRowStringArray(row.source_refs_json),

--- a/Source/AgentSystem/Memory/AgentMemoryRowEncoders.ts
+++ b/Source/AgentSystem/Memory/AgentMemoryRowEncoders.ts
@@ -135,6 +135,7 @@ export function memoryObservationToRow(record: AgentMemoryObservationRecord): Re
     id: record.id,
     uri: record.uri,
     memory_uri: record.memoryUri,
+    write_sequence: record.writeSequence,
     operation: record.operation,
     candidate_uris_json: JSON.stringify(record.candidateUris),
     source_refs_json: JSON.stringify(record.sourceRefs),

--- a/Source/AgentSystem/Memory/AgentMemorySourceRepository.ts
+++ b/Source/AgentSystem/Memory/AgentMemorySourceRepository.ts
@@ -181,6 +181,7 @@ export interface AgentMemoryObservationRecord {
   id: string;
   uri: string;
   memoryUri: string;
+  writeSequence: number;
   operation: AgentMemoryLearningOperation;
   candidateUris: string[];
   sourceRefs: string[];

--- a/Source/AgentSystem/Memory/AgentMemorySqlRows.ts
+++ b/Source/AgentSystem/Memory/AgentMemorySqlRows.ts
@@ -121,6 +121,7 @@ export interface MemoryObservationRow {
   id: string;
   uri: string;
   memory_uri: string;
+  write_sequence: number;
   operation: AgentMemoryLearningOperation;
   candidate_uris_json: string;
   source_refs_json: string;

--- a/Source/AgentSystem/Memory/AgentMemorySqlSchema.ts
+++ b/Source/AgentSystem/Memory/AgentMemorySqlSchema.ts
@@ -189,6 +189,28 @@ const AgentMemoryLearningJobsMigrationSql = `
       ON memory_learning_jobs(status, next_attempt_at_ms, updated_at_ms);
 `;
 
+const AgentMemoryObservationWriteSequenceMigrationSql = `
+    ALTER TABLE memory_observations
+      ADD COLUMN write_sequence INTEGER NOT NULL DEFAULT 0;
+    WITH ordered_observations AS (
+      SELECT
+        id,
+        ROW_NUMBER() OVER (PARTITION BY memory_uri ORDER BY rowid ASC) AS write_sequence
+      FROM memory_observations
+    )
+    UPDATE memory_observations
+    SET write_sequence = (
+      SELECT ordered.write_sequence
+      FROM ordered_observations AS ordered
+      WHERE ordered.id = memory_observations.id
+    );
+    DROP INDEX idx_memory_observations_memory_time;
+    CREATE UNIQUE INDEX idx_memory_observations_memory_sequence
+      ON memory_observations(memory_uri, write_sequence);
+    CREATE INDEX idx_memory_observations_memory_time
+      ON memory_observations(memory_uri, created_at_ms, write_sequence);
+`;
+
 export const AgentMemoryDatabaseMigrations = Object.freeze([
   defineAgentSqliteMigration({
     version: 1,
@@ -199,6 +221,11 @@ export const AgentMemoryDatabaseMigrations = Object.freeze([
     version: 2,
     name: "memory_learning_jobs",
     sql: AgentMemoryLearningJobsMigrationSql,
+  }),
+  defineAgentSqliteMigration({
+    version: 3,
+    name: "memory_observation_write_sequence",
+    sql: AgentMemoryObservationWriteSequenceMigrationSql,
   }),
 ]);
 

--- a/Source/AgentSystem/Memory/AgentMemorySqliteSourceRepository.ts
+++ b/Source/AgentSystem/Memory/AgentMemorySqliteSourceRepository.ts
@@ -40,6 +40,7 @@ import type {
   AgentMemoryItemRecord,
   AgentMemoryItemVectorRecord,
   AgentMemoryItemVectorWrite,
+  AgentMemoryLearningActionRecord,
   AgentMemoryLearningWriteInput,
   AgentMemoryLearningJobRecord,
   AgentMemoryObservationRecord,
@@ -104,7 +105,7 @@ export class SqliteAgentMemorySourceRepository implements AgentMemorySourceRepos
           this.statements.updateMemoryItemStmt.run(memoryItemToRow(item));
           this.markCandidatesPromoted(action.candidateUris, item.uri, learnedAt);
           this.statements.insertMemoryObservationStmt.run(
-            memoryObservationToRow(buildMemoryObservation(input.episode, item.uri, action, learnedAt)),
+            memoryObservationToRow(this.createMemoryObservation(input.episode, item.uri, action, learnedAt)),
           );
           written.push(item);
           continue;
@@ -116,7 +117,7 @@ export class SqliteAgentMemorySourceRepository implements AgentMemorySourceRepos
           this.statements.updateMemoryItemStmt.run(memoryItemToRow(item));
           this.markCandidatesPromoted(action.candidateUris, item.uri, learnedAt);
           this.statements.insertMemoryObservationStmt.run(
-            memoryObservationToRow(buildMemoryObservation(input.episode, item.uri, action, learnedAt)),
+            memoryObservationToRow(this.createMemoryObservation(input.episode, item.uri, action, learnedAt)),
           );
           written.push(item);
           continue;
@@ -130,7 +131,7 @@ export class SqliteAgentMemorySourceRepository implements AgentMemorySourceRepos
         this.statements.insertMemoryItemStmt.run(memoryItemToRow(item));
         this.markCandidatesPromoted(action.candidateUris, item.uri, learnedAt);
         this.statements.insertMemoryObservationStmt.run(
-          memoryObservationToRow(buildMemoryObservation(input.episode, item.uri, action, learnedAt)),
+          memoryObservationToRow(this.createMemoryObservation(input.episode, item.uri, action, learnedAt)),
         );
         written.push(item);
       }
@@ -151,7 +152,7 @@ export class SqliteAgentMemorySourceRepository implements AgentMemorySourceRepos
         const item = buildReinforcedMemoryItem(anchor, current, action, writtenAt);
         this.statements.updateMemoryItemStmt.run(memoryItemToRow(item));
         this.statements.insertMemoryObservationStmt.run(
-          memoryObservationToRow(buildMemoryObservation(anchor, item.uri, action, writtenAt)),
+          memoryObservationToRow(this.createMemoryObservation(anchor, item.uri, action, writtenAt)),
         );
         written = item;
         return;
@@ -162,7 +163,7 @@ export class SqliteAgentMemorySourceRepository implements AgentMemorySourceRepos
         const item = buildUpdatedMemoryItem(anchor, current, action, writtenAt);
         this.statements.updateMemoryItemStmt.run(memoryItemToRow(item));
         this.statements.insertMemoryObservationStmt.run(
-          memoryObservationToRow(buildMemoryObservation(anchor, item.uri, action, writtenAt)),
+          memoryObservationToRow(this.createMemoryObservation(anchor, item.uri, action, writtenAt)),
         );
         written = item;
         return;
@@ -175,7 +176,7 @@ export class SqliteAgentMemorySourceRepository implements AgentMemorySourceRepos
       const item = buildNewMemoryItem(anchor, action, writtenAt);
       this.statements.insertMemoryItemStmt.run(memoryItemToRow(item));
       this.statements.insertMemoryObservationStmt.run(
-        memoryObservationToRow(buildMemoryObservation(anchor, item.uri, action, writtenAt)),
+        memoryObservationToRow(this.createMemoryObservation(anchor, item.uri, action, writtenAt)),
       );
       written = item;
     });
@@ -322,6 +323,19 @@ export class SqliteAgentMemorySourceRepository implements AgentMemorySourceRepos
 
   close(): void {
     this.kernel.close();
+  }
+
+  private createMemoryObservation(
+    episode: AgentMemoryEpisodeRecord,
+    memoryUri: string,
+    action: AgentMemoryLearningActionRecord,
+    observedAt: string,
+  ): AgentMemoryObservationRecord {
+    const row = this.statements.nextMemoryObservationWriteSequenceStmt.get(memoryUri);
+    if (!row || !Number.isSafeInteger(row.next_write_sequence) || row.next_write_sequence < 1) {
+      throw new Error(`Unable to allocate memory observation write sequence for ${memoryUri}.`);
+    }
+    return buildMemoryObservation(episode, memoryUri, action, observedAt, row.next_write_sequence);
   }
 
   private readExistingMemory(uri: string | undefined): AgentMemoryItemRecord {


### PR DESCRIPTION
## Summary

- persist a per-memory write sequence for observations
- migrate existing SQLite data and align in-memory ordering semantics
- cover same-millisecond create, reinforce, and update writes

## Verification

- npm run test.backend (616 tests)
- npm run check.types
- npm run build
- targeted ESLint and Prettier checks