### PR TITLE
fix(runtime): stabilize sandbox imports and Nano distribution

### DIFF
--- a/Apps/DevServer.ts
+++ b/Apps/DevServer.ts
@@ -1,18 +1,21 @@
 import { startSeneraServer } from "./ServerRuntime.js";
 import { createSourceAgentMcpRuntimeModuleResolver } from "../Source/AgentSystem/Mcp/AgentMcpRuntimeModuleResolver.js";
 import { resolveAgentSandboxDevelopmentBundleRoot } from "../Source/AgentSystem/Sandbox/AgentSandboxBundlePaths.js";
-import { resolveSeneraServerConfigPath, startSeneraGvisorWorkerProcess } from "./GvisorWorkerProcess.js";
+import { startSeneraGvisorWorkerProcess } from "./GvisorWorkerProcess.js";
+import { ensureSeneraDevelopmentConfig } from "./RuntimeConfigBootstrap.js";
 
 async function main(): Promise<void> {
   const workspaceRoot = process.cwd();
+  const configPath = ensureSeneraDevelopmentConfig(workspaceRoot);
   const worker = await startSeneraGvisorWorkerProcess({
     workspaceRoot,
-    configPath: resolveSeneraServerConfigPath(workspaceRoot),
+    configPath,
     entrypoint: "Apps/GvisorWorker.ts",
     nodeArguments: ["--import", "tsx"],
     resourcesPath: workspaceRoot,
   });
   const handle = startSeneraServer({
+    configPath,
     runtimeModuleResolver: createSourceAgentMcpRuntimeModuleResolver(workspaceRoot),
     sandboxBundleRoot: resolveAgentSandboxDevelopmentBundleRoot(workspaceRoot),
     sandboxProvider: worker?.provider,

--- a/Apps/DockerServer.ts
+++ b/Apps/DockerServer.ts
@@ -9,7 +9,6 @@ import {
   resolveServerConfig,
 } from "../Source/AgentSystem/AgentDefaults.js";
 import { loadConfigFile } from "../Source/AgentSystem/Config/AgentConfigService.js";
-import { writeAgentConfigJsonMirror } from "../Source/AgentSystem/Config/AgentConfigServicePaths.js";
 import { moduleDirPath } from "../Source/AgentSystem/Core/AgentPath.js";
 import { resolveAgentLocalAdminAccountPath } from "../Source/AgentSystem/Auth/AgentLocalAdminAccount.js";
 import { AgentGvisorWorkerSocketClient } from "../Source/AgentSystem/Sandbox/Gvisor/AgentGvisorWorkerClient.js";
@@ -19,6 +18,7 @@ import { synchronizeDockerAdminAccount } from "./DockerAdminAccountSync.js";
 import { resolveAgentSandboxPackagedBundleRoot } from "../Source/AgentSystem/Sandbox/AgentSandboxBundlePaths.js";
 import type { AgentSandboxRuntimeProvider } from "../Source/AgentSystem/Sandbox/AgentSandboxRuntimeTypes.js";
 import type { SeneraGvisorWorkerClient } from "../Source/AgentSystem/Execution/SeneraGvisorTypes.js";
+import { ensureRuntimeConfigFile } from "./RuntimeConfigBootstrap.js";
 
 const AppRoot = resolveAppRoot();
 const SandboxBundleRoot = resolveAgentSandboxPackagedBundleRoot(AppRoot);
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
   fs.mkdirSync(WorkspaceRoot, { recursive: true });
   syncBundledUserPlugins();
   ensureFrontendBundleExists();
-  ensureRuntimeConfigFile();
+  ensureRuntimeConfigFile({ configPath: ConfigPath, templatePath: ExampleConfigPath });
 
   const config = loadConfigFile(ConfigPath);
   const worker = new AgentGvisorWorkerSocketClient({ socketPath: resolveDockerGvisorWorkerSocketPath() });
@@ -96,15 +96,6 @@ function ensureFrontendBundleExists(): void {
   }
 
   throw new Error(`容器前端产物缺失: ${indexPath}`);
-}
-
-function ensureRuntimeConfigFile(): void {
-  if (fs.existsSync(ConfigPath)) {
-    return;
-  }
-
-  const seedConfig = loadConfigFile(ExampleConfigPath);
-  writeAgentConfigJsonMirror(seedConfig, ConfigPath);
 }
 
 function createDockerRuntimeProjection(

--- a/Apps/GvisorWorkerProcess.ts
+++ b/Apps/GvisorWorkerProcess.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import os from "node:os";
-import path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
 import { resolveSandboxRuntimeConfig } from "../Source/AgentSystem/AgentDefaults.js";
@@ -105,9 +104,4 @@ function delay(milliseconds: number): Promise<void> {
 
 function isMissingFile(error: unknown): boolean {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
-}
-
-export function resolveSeneraServerConfigPath(workspaceRoot: string): string {
-  const configured = process.env.AGENT_CONFIG_PATH?.trim();
-  return configured ? path.resolve(workspaceRoot, configured) : path.resolve(workspaceRoot, "senera.config.json");
 }

--- a/Apps/RuntimeConfigBootstrap.ts
+++ b/Apps/RuntimeConfigBootstrap.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+import { loadConfigFile } from "../Source/AgentSystem/Config/AgentConfigService.js";
+import { writeAgentConfigJsonMirror } from "../Source/AgentSystem/Config/AgentConfigServicePaths.js";
+
+const RuntimeConfigFileName = "senera.config.json";
+const RuntimeConfigTemplateFileName = "senera.config.example.json";
+
+export interface RuntimeConfigSeedOptions {
+  configPath: string;
+  templatePath: string;
+}
+
+export function ensureRuntimeConfigFile(options: RuntimeConfigSeedOptions): void {
+  if (fs.existsSync(options.configPath)) return;
+  writeAgentConfigJsonMirror(loadConfigFile(options.templatePath), options.configPath);
+}
+
+export function ensureSeneraDevelopmentConfig(workspaceRoot: string): string {
+  const configPath = resolveSeneraServerConfigPath(workspaceRoot);
+  ensureRuntimeConfigFile({
+    configPath,
+    templatePath: path.resolve(workspaceRoot, RuntimeConfigTemplateFileName),
+  });
+  return configPath;
+}
+
+export function resolveSeneraServerConfigPath(workspaceRoot: string): string {
+  const configured = process.env.AGENT_CONFIG_PATH?.trim();
+  return path.resolve(workspaceRoot, configured || RuntimeConfigFileName);
+}

--- a/Apps/Server.ts
+++ b/Apps/Server.ts
@@ -1,17 +1,20 @@
 import { startSeneraServer } from "./ServerRuntime.js";
 import { createCompiledAgentMcpRuntimeModuleResolver } from "../Source/AgentSystem/Mcp/AgentMcpRuntimeModuleResolver.js";
 import { resolveAgentSandboxDevelopmentBundleRoot } from "../Source/AgentSystem/Sandbox/AgentSandboxBundlePaths.js";
-import { resolveSeneraServerConfigPath, startSeneraGvisorWorkerProcess } from "./GvisorWorkerProcess.js";
+import { startSeneraGvisorWorkerProcess } from "./GvisorWorkerProcess.js";
+import { ensureSeneraDevelopmentConfig } from "./RuntimeConfigBootstrap.js";
 
 async function main(): Promise<void> {
   const workspaceRoot = process.cwd();
+  const configPath = ensureSeneraDevelopmentConfig(workspaceRoot);
   const worker = await startSeneraGvisorWorkerProcess({
     workspaceRoot,
-    configPath: resolveSeneraServerConfigPath(workspaceRoot),
+    configPath,
     entrypoint: "Dist/Apps/GvisorWorker.js",
     resourcesPath: workspaceRoot,
   });
   const handle = startSeneraServer({
+    configPath,
     runtimeModuleResolver: createCompiledAgentMcpRuntimeModuleResolver(workspaceRoot),
     sandboxBundleRoot: resolveAgentSandboxDevelopmentBundleRoot(workspaceRoot),
     sandboxProvider: worker?.provider,

--- a/Build/Distributions/GenerateNanoDistribution.ts
+++ b/Build/Distributions/GenerateNanoDistribution.ts
@@ -27,6 +27,11 @@ interface PackageProjection {
   readonly optionalDependencies: DependencyProjection;
 }
 
+interface FileProjection {
+  readonly source: string;
+  readonly target: string;
+}
+
 interface NanoDistributionContract {
   readonly schemaVersion: number;
   readonly id: string;
@@ -37,6 +42,7 @@ interface NanoDistributionContract {
   };
   readonly files: {
     readonly gitPathspecs: readonly string[];
+    readonly projections: readonly FileProjection[];
   };
   readonly rootPackage: PackageProjection;
   readonly workspacePackages: Readonly<Record<string, { readonly scripts: readonly string[] }>>;
@@ -83,6 +89,7 @@ function main(): void {
   const outputRoot = prepareOutputRoot(sourceRoot, invocation.output);
 
   copySelectedFiles(sourceRoot, outputRoot, contract.files.gitPathspecs);
+  projectFiles(sourceRoot, outputRoot, contract.files.projections);
   projectRootPackage(sourceRoot, outputRoot, contract.rootPackage);
   projectWorkspacePackages(outputRoot, contract.workspacePackages);
   projectTypescriptConfig(sourceRoot, outputRoot, contract.typescript.include);
@@ -124,7 +131,7 @@ function parseInvocation(args: readonly string[]): Invocation {
 function readContract(contractPath: string): NanoDistributionContract {
   const value = readJsonFile(contractPath);
   if (!isRecord(value)) throw new Error(`Nano distribution contract must be an object: ${contractPath}`);
-  if (value.schemaVersion !== 1 || value.id !== "nano") {
+  if (value.schemaVersion !== 2 || value.id !== "nano") {
     throw new Error(`Unsupported Nano distribution contract version or id: ${contractPath}`);
   }
   if (!isRecord(value.source) || !isRecord(value.files) || !isRecord(value.rootPackage)) {
@@ -137,6 +144,7 @@ function readContract(contractPath: string): NanoDistributionContract {
   assertString(value.source.outputBranch, "source.outputBranch");
   assertString(value.source.repositoryUrl, "source.repositoryUrl");
   assertStringArray(value.files.gitPathspecs, "files.gitPathspecs");
+  assertFileProjections(value.files.projections);
   assertPackageProjection(value.rootPackage, "rootPackage");
   assertStringArray(value.typescript.include, "typescript.include");
   assertString(value.generatedFiles.readmeTemplate, "generatedFiles.readmeTemplate");
@@ -146,6 +154,22 @@ function readContract(contractPath: string): NanoDistributionContract {
     assertStringArray(projection.scripts, `workspacePackages.${packagePath}.scripts`);
   }
   return value as unknown as NanoDistributionContract;
+}
+
+function assertFileProjections(value: unknown): void {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error("files.projections must be a non-empty array.");
+  }
+  const targets = new Set<string>();
+  for (const [index, projection] of value.entries()) {
+    if (!isRecord(projection)) throw new Error(`files.projections.${index} must be an object.`);
+    assertString(projection.source, `files.projections.${index}.source`);
+    assertString(projection.target, `files.projections.${index}.target`);
+    if (targets.has(projection.target)) {
+      throw new Error(`files.projections declares duplicate target: ${projection.target}`);
+    }
+    targets.add(projection.target);
+  }
 }
 
 function assertPackageProjection(value: Record<string, unknown>, label: string): void {
@@ -197,6 +221,19 @@ function copySelectedFiles(sourceRoot: string, outputRoot: string, pathspecs: re
     mkdirSync(path.dirname(destinationPath), { recursive: true });
     copyFileSync(sourcePath, destinationPath);
     chmodSync(destinationPath, stats.mode & 0o777);
+  }
+}
+
+function projectFiles(sourceRoot: string, outputRoot: string, projections: readonly FileProjection[]): void {
+  for (const projection of projections) {
+    const sourcePath = resolveContainedPath(sourceRoot, projection.source);
+    const targetPath = resolveContainedPath(outputRoot, projection.target);
+    if (existsSync(targetPath)) throw new Error(`Nano projected file target already exists: ${projection.target}`);
+    const stats = lstatSync(sourcePath);
+    if (!stats.isFile()) throw new Error(`Nano projected source must be a regular file: ${projection.source}`);
+    mkdirSync(path.dirname(targetPath), { recursive: true });
+    copyFileSync(sourcePath, targetPath);
+    chmodSync(targetPath, stats.mode & 0o777);
   }
 }
 

--- a/Build/Distributions/NanoDevServer.ts.template
+++ b/Build/Distributions/NanoDevServer.ts.template
@@ -1,0 +1,24 @@
+import { startSeneraServer } from "./ServerRuntime.js";
+import { createSourceAgentMcpRuntimeModuleResolver } from "../Source/AgentSystem/Mcp/AgentMcpRuntimeModuleResolver.js";
+import { resolveAgentSandboxDevelopmentBundleRoot } from "../Source/AgentSystem/Sandbox/AgentSandboxBundlePaths.js";
+import { AgentSandboxRuntimeProviders } from "../Source/AgentSystem/Sandbox/AgentSandboxRuntimeTypes.js";
+import { ensureSeneraDevelopmentConfig } from "./RuntimeConfigBootstrap.js";
+
+const workspaceRoot = process.cwd();
+const configPath = ensureSeneraDevelopmentConfig(workspaceRoot);
+const handle = startSeneraServer({
+  configPath,
+  runtimeModuleResolver: createSourceAgentMcpRuntimeModuleResolver(workspaceRoot),
+  sandboxBundleRoot: resolveAgentSandboxDevelopmentBundleRoot(workspaceRoot),
+  sandboxProvider: AgentSandboxRuntimeProviders.Microsandbox,
+});
+
+let shutdownPromise: Promise<void> | undefined;
+const shutdown = (): void => {
+  shutdownPromise ??= handle.stop().finally(() => {
+    process.exit(0);
+  });
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/Build/Distributions/NanoDistribution.json
+++ b/Build/Distributions/NanoDistribution.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./NanoDistribution.schema.json",
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "id": "nano",
   "source": {
     "branch": "main",
@@ -17,7 +17,7 @@
       "package.json",
       "package-lock.json",
       "senera.config.example.json",
-      "Apps/DevServer.ts",
+      "Apps/RuntimeConfigBootstrap.ts",
       "Apps/ServerRuntime.ts",
       "Apps/ServerWatch.ts",
       "Source",
@@ -26,7 +26,15 @@
       "Plugins",
       "System",
       "baml_src",
+      ":(exclude,glob)Source/AgentSystem/Sandbox/Gvisor/AgentGvisorDockerRuntime.ts",
+      ":(exclude,glob)Source/AgentSystem/Sandbox/Gvisor/AgentGvisorWorkerServer.ts",
       ":(exclude,glob)Frontend/**/*.stories.tsx"
+    ],
+    "projections": [
+      {
+        "source": "Build/Distributions/NanoDevServer.ts.template",
+        "target": "Apps/DevServer.ts"
+      }
     ]
   },
   "rootPackage": {
@@ -41,7 +49,7 @@
     "scripts": ["dev", "dev.server", "dev.server.dry-run", "dev.frontend", "check.types", "check.frontend-types"],
     "dependencies": {
       "mode": "exclude",
-      "names": ["fast-glob", "tslib"]
+      "names": ["dockerode", "fast-glob", "tar-fs", "tslib"]
     },
     "devDependencies": {
       "mode": "include",

--- a/Build/Distributions/NanoDistribution.schema.json
+++ b/Build/Distributions/NanoDistribution.schema.json
@@ -16,7 +16,7 @@
   ],
   "properties": {
     "$schema": { "type": "string" },
-    "schemaVersion": { "const": 1 },
+    "schemaVersion": { "const": 2 },
     "id": { "const": "nano" },
     "source": {
       "type": "object",
@@ -31,13 +31,18 @@
     "files": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["gitPathspecs"],
+      "required": ["gitPathspecs", "projections"],
       "properties": {
         "gitPathspecs": {
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
           "items": { "type": "string", "minLength": 1 }
+        },
+        "projections": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/fileProjection" }
         }
       }
     },
@@ -73,6 +78,15 @@
     }
   },
   "$defs": {
+    "fileProjection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "target"],
+      "properties": {
+        "source": { "type": "string", "minLength": 1 },
+        "target": { "type": "string", "minLength": 1 }
+      }
+    },
     "stringList": {
       "type": "array",
       "uniqueItems": true,

--- a/Build/Distributions/NanoREADME.md
+++ b/Build/Distributions/NanoREADME.md
@@ -21,5 +21,5 @@ npm run dev
 
 当前快照来源：[{{sourceCommitShort}}]({{repositoryUrl}}/commit/{{sourceCommit}})。精确来源也记录在 `SENERA_NANO.json`。
 
-Nano 不包含 Docker、Electron 桌面打包、测试、覆盖率、发布流水线和相关工具依赖。
+Nano 开发入口固定使用 microsandbox，不启动 Docker Engine 或 gVisor Worker。Nano 不包含 Docker、Electron 桌面打包、测试、覆盖率、发布流水线和相关工具依赖。
 正式发布使用的 OS Sandbox Bundle 也不会进入 Nano；需要构建或验证该 Bundle 时请使用完整的 `{{sourceBranch}}` 分支。

--- a/Scripts/BackendTests/Config/RuntimeConfigBootstrapBehavior.test.ts
+++ b/Scripts/BackendTests/Config/RuntimeConfigBootstrapBehavior.test.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { ensureRuntimeConfigFile } from "../../../Apps/RuntimeConfigBootstrap.js";
+import { loadConfigFile } from "../../../Source/AgentSystem/Config/AgentConfigService.js";
+import { createTemporaryDirectory, removeDirectory } from "../Support/AgentTestFixtures.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  while (temporaryDirectories.length > 0) removeDirectory(temporaryDirectories.pop()!);
+});
+
+describe("runtime config bootstrap behavior", () => {
+  test("creates a normalized config from the template without replacing an existing file", () => {
+    const root = createTemporaryDirectory("senera-runtime-config-bootstrap");
+    temporaryDirectories.push(root);
+    const configPath = path.join(root, "senera.config.json");
+    const templatePath = path.resolve("senera.config.example.json");
+
+    ensureRuntimeConfigFile({ configPath, templatePath });
+    expect(loadConfigFile(configPath)).toEqual(loadConfigFile(templatePath));
+
+    const existing = `${fs.readFileSync(configPath, "utf8")}\n`;
+    fs.writeFileSync(configPath, existing, "utf8");
+    ensureRuntimeConfigFile({ configPath, templatePath });
+    expect(fs.readFileSync(configPath, "utf8")).toBe(existing);
+  });
+});

--- a/Scripts/BackendTests/Execution/GvisorDockerEngineRuntimeBehavior.test.ts
+++ b/Scripts/BackendTests/Execution/GvisorDockerEngineRuntimeBehavior.test.ts
@@ -4,7 +4,7 @@ import Docker from "dockerode";
 import { describe, expect, test, vi } from "vitest";
 import {
   AgentGvisorDockerEngineRuntime,
-  findImportedDockerImageId,
+  resolveImportedDockerImageId,
   resolveAgentDockerEngineSandboxProvider,
 } from "../../../Source/AgentSystem/Sandbox/Gvisor/AgentGvisorDockerRuntime.js";
 import {
@@ -90,12 +90,49 @@ describe("Docker Engine sandbox runtime", () => {
     const importedReference = sourceReference.replace("docker.io/library/", "");
 
     expect(
-      findImportedDockerImageId(
-        [{ Id: "sha256:image-config", RepoTags: [importedReference], RepoDigests: [] }],
-        sourceReference,
-      ),
+      resolveImportedDockerImageId({
+        imagesBefore: [],
+        imagesAfter: [{ Id: "sha256:image-config", RepoTags: [importedReference], RepoDigests: [] }],
+        loadEvents: [],
+        expectedReferences: [sourceReference],
+      }),
     ).toBe("sha256:image-config");
-    expect(() => findImportedDockerImageId([], sourceReference)).toThrow("imported 0 images");
+  });
+
+  test("uses Docker's load response for an already-present dangling OCI image", () => {
+    const imageId = `sha256:${"a".repeat(64)}`;
+    const danglingImage = { Id: imageId, RepoTags: ["<none>:<none>"], RepoDigests: [] };
+
+    expect(
+      resolveImportedDockerImageId({
+        imagesBefore: [danglingImage],
+        imagesAfter: [danglingImage],
+        loadEvents: [{ stream: `Loaded image ID: ${imageId}\n` }],
+        expectedReferences: ["senera.local/runtime:1.0.2"],
+      }),
+    ).toBe(imageId);
+  });
+
+  test("uses the unique inventory delta when Docker omits the loaded image identity", () => {
+    expect(
+      resolveImportedDockerImageId({
+        imagesBefore: [{ Id: "sha256:existing" }],
+        imagesAfter: [{ Id: "sha256:existing" }, { Id: "sha256:imported" }],
+        loadEvents: [],
+        expectedReferences: ["senera.local/runtime:1.0.2"],
+      }),
+    ).toBe("sha256:imported");
+  });
+
+  test("rejects an ambiguous Docker image inventory delta", () => {
+    expect(() =>
+      resolveImportedDockerImageId({
+        imagesBefore: [],
+        imagesAfter: [{ Id: "sha256:first" }, { Id: "sha256:second" }],
+        loadEvents: [],
+        expectedReferences: ["senera.local/runtime:1.0.2"],
+      }),
+    ).toThrow("load added multiple images");
   });
 });
 

--- a/Scripts/BackendTests/Execution/GvisorWorkerServerBehavior.test.ts
+++ b/Scripts/BackendTests/Execution/GvisorWorkerServerBehavior.test.ts
@@ -26,7 +26,21 @@ describe("gVisor worker server", () => {
         isolation: "gvisor",
         imageReady: true,
       });
-      await expect(client.prepare({ timeoutMs: 1_000 })).resolves.toBeUndefined();
+      const preparationProgress: unknown[] = [];
+      await expect(
+        client.prepare({
+          timeoutMs: 1_000,
+          onProgress: (progress) => preparationProgress.push(progress),
+        }),
+      ).resolves.toBeUndefined();
+      expect(preparationProgress).toEqual([
+        {
+          stage: "verifying_archive",
+          item: "sandbox.oci.tar.gz",
+          downloadedBytes: 1024,
+          totalBytes: 4096,
+        },
+      ]);
 
       const process = await client.start(createExecutionRequest());
       await process.write(Buffer.from("first input"));
@@ -152,8 +166,14 @@ class RecordingRuntime implements AgentGvisorDockerRuntime {
     };
   }
 
-  async prepare(): Promise<void> {
+  async prepare(input?: Parameters<AgentGvisorDockerRuntime["prepare"]>[0]): Promise<void> {
     this.preparations += 1;
+    input?.onProgress?.({
+      stage: "verifying_archive",
+      item: "sandbox.oci.tar.gz",
+      downloadedBytes: 1024,
+      totalBytes: 4096,
+    });
   }
 
   async start(_request: AgentGvisorExecutionRequest): Promise<AgentGvisorDockerProcess> {

--- a/Scripts/VerifyNanoDistribution.ts
+++ b/Scripts/VerifyNanoDistribution.ts
@@ -6,10 +6,14 @@ import path from "node:path";
 import { Ajv2020 } from "ajv/dist/2020.js";
 
 interface NanoContract {
+  readonly schemaVersion: number;
   readonly source: {
     readonly branch: string;
     readonly outputBranch: string;
     readonly repositoryUrl: string;
+  };
+  readonly files: {
+    readonly projections: readonly { readonly source: string; readonly target: string }[];
   };
   readonly rootPackage: {
     readonly scripts: readonly string[];
@@ -43,6 +47,9 @@ const ForbiddenPackages = [
   "@testing-library/react",
   "@testing-library/user-event",
   "@vitest/coverage-v8",
+  "@types/dockerode",
+  "@types/tar-fs",
+  "dockerode",
   "electron",
   "electron-builder",
   "eslint",
@@ -51,6 +58,7 @@ const ForbiddenPackages = [
   "rimraf",
   "semver",
   "ts-json-schema-generator",
+  "tar-fs",
   "vitest",
 ] as const;
 
@@ -136,6 +144,8 @@ function verifyGeneratedFiles(outputRoot: string): void {
       file.startsWith("Build/") ||
       file.startsWith("Scripts/") ||
       file.startsWith("Apps/Desktop/") ||
+      file === "Source/AgentSystem/Sandbox/Gvisor/AgentGvisorDockerRuntime.ts" ||
+      file === "Source/AgentSystem/Sandbox/Gvisor/AgentGvisorWorkerServer.ts" ||
       file === "Apps/DockerServer.ts" ||
       file === "Apps/DockerAdminAccountSync.ts" ||
       file === "Dockerfile" ||
@@ -146,8 +156,15 @@ function verifyGeneratedFiles(outputRoot: string): void {
 
   assert.deepEqual(
     files.filter((file) => file.startsWith("Apps/")),
-    ["Apps/DevServer.ts", "Apps/ServerRuntime.ts", "Apps/ServerWatch.ts"],
+    ["Apps/DevServer.ts", "Apps/RuntimeConfigBootstrap.ts", "Apps/ServerRuntime.ts", "Apps/ServerWatch.ts"],
   );
+  const projectedDevServer = fs.readFileSync(path.join(outputRoot, "Apps", "DevServer.ts"), "utf8");
+  assert.ok(projectedDevServer.includes("AgentSandboxRuntimeProviders.Microsandbox"));
+  assert.ok(projectedDevServer.includes("ensureSeneraDevelopmentConfig"));
+  assert.ok(!projectedDevServer.includes("GvisorWorker"));
+  assert.deepEqual(contract.files.projections, [
+    { source: "Build/Distributions/NanoDevServer.ts.template", target: "Apps/DevServer.ts" },
+  ]);
   for (const required of [
     "README.md",
     "SENERA_NANO.json",
@@ -224,6 +241,7 @@ function verifySourceMetadata(outputRoot: string, contractValue: NanoContract, s
       commit: sourceSha,
     },
   });
+  assert.equal(contractValue.schemaVersion, 2);
   const readme = fs.readFileSync(path.join(outputRoot, "README.md"), "utf8");
   assert.ok(readme.includes(sourceSha));
   assert.ok(!/\{\{[a-zA-Z][a-zA-Z0-9]*\}\}/u.test(readme), "Nano README contains unresolved template values.");

--- a/Source/AgentSystem/Sandbox/Gvisor/AgentGvisorDockerRuntime.ts
+++ b/Source/AgentSystem/Sandbox/Gvisor/AgentGvisorDockerRuntime.ts
@@ -370,22 +370,34 @@ export class AgentGvisorDockerEngineRuntime implements AgentGvisorDockerRuntime 
       bundleRoot: this.options.bundleRoot!,
       onProgress,
     });
+    onProgress?.({
+      stage: AgentSandboxPreparationStages.ImportingImage,
+      item: verified.manifest.runtimeImage,
+    });
+    const imagesBefore = await this.listImages();
     const archive = createReadStream(verified.archivePath).pipe(createGunzip());
-    const stream = await this.options.docker.loadImage(archive, { quiet: true });
-    await new Promise<void>((resolve, reject) => {
-      dockerModem(this.options.docker).followProgress(stream, (error) => {
+    const stream = await this.options.docker.loadImage(archive);
+    const loadEvents = await new Promise<readonly unknown[]>((resolve, reject) => {
+      dockerModem(this.options.docker).followProgress(stream, (error, output) => {
         if (error) reject(dockerOperationError("load bundled image", error));
-        else resolve();
+        else resolve(output);
       });
     });
     const target = splitImageReference(this.resolvedContract.image.runtimeImage);
-    const importedImage = await this.resolveImportedBundleImage(this.resolvedContract.image.sourceImage);
+    const imagesAfter = await this.listImages();
+    const importedImage = this.options.docker.getImage(
+      resolveImportedDockerImageId({
+        imagesBefore,
+        imagesAfter,
+        loadEvents,
+        expectedReferences: [this.resolvedContract.image.runtimeImage, this.resolvedContract.image.sourceImage],
+      }),
+    );
     await importedImage.tag(target);
   }
 
-  private async resolveImportedBundleImage(sourceReference: string): Promise<Docker.Image> {
-    const images = (await this.options.docker.listImages({ all: true })) as DockerImageSummary[];
-    return this.options.docker.getImage(findImportedDockerImageId(images, sourceReference));
+  private async listImages(): Promise<readonly DockerImageSummary[]> {
+    return (await this.options.docker.listImages({ all: true })) as DockerImageSummary[];
   }
 
   private async stageRootfsCopies(copies: AgentGvisorExecutionRequest["rootfsCopies"]): Promise<string> {
@@ -421,19 +433,46 @@ export interface DockerImageSummary {
   RepoDigests?: string[];
 }
 
-export function findImportedDockerImageId(images: readonly DockerImageSummary[], sourceReference: string): string {
-  const expected = normalizeDockerImageReference(sourceReference);
-  const matches = images.filter((image) =>
-    [...(image.RepoTags ?? []), ...(image.RepoDigests ?? [])].some(
-      (reference) => normalizeDockerImageReference(reference) === expected,
-    ),
-  );
-  if (matches.length !== 1 || !matches[0]?.Id) {
+export interface ImportedDockerImageResolutionInput {
+  imagesBefore: readonly DockerImageSummary[];
+  imagesAfter: readonly DockerImageSummary[];
+  loadEvents: readonly unknown[];
+  expectedReferences: readonly string[];
+}
+
+/** Resolves the one image identified by Docker's load result without trusting an unrelated dangling image. */
+export function resolveImportedDockerImageId(input: ImportedDockerImageResolutionInput): string {
+  const beforeIds = dockerImageIds(input.imagesBefore);
+  const afterIds = dockerImageIds(input.imagesAfter);
+  const referencedIds = findDockerImageIdsByReferences(input.imagesAfter, input.expectedReferences);
+  const loadIdentity = readDockerImageLoadIdentity(input.loadEvents);
+  const responseIds = new Set<string>();
+
+  for (const imageId of loadIdentity.imageIds) {
+    if (!afterIds.has(imageId)) {
+      throw new Error(`Docker reported loaded image ${imageId}, but it is absent from the post-import inventory.`);
+    }
+    responseIds.add(imageId);
+  }
+  for (const reference of loadIdentity.references) {
+    for (const imageId of findDockerImageIdsByReferences(input.imagesAfter, [reference])) responseIds.add(imageId);
+  }
+
+  const identifiedIds = new Set([...referencedIds, ...responseIds]);
+  if (identifiedIds.size === 1) return firstSetValue(identifiedIds);
+  if (identifiedIds.size > 1) {
     throw new Error(
-      `Verified Sandbox Bundle imported ${matches.length} images matching ${sourceReference}; exactly one is required.`,
+      `Verified Sandbox Bundle load identified multiple images: ${[...identifiedIds].sort().join(", ")}.`,
     );
   }
-  return matches[0].Id;
+
+  const addedIds = new Set([...afterIds].filter((imageId) => !beforeIds.has(imageId)));
+  if (addedIds.size === 1) return firstSetValue(addedIds);
+  throw new Error(
+    addedIds.size === 0
+      ? "Verified Sandbox Bundle was loaded, but Docker did not expose its image identity."
+      : `Verified Sandbox Bundle load added multiple images: ${[...addedIds].sort().join(", ")}.`,
+  );
 }
 
 interface DockerContainerWaitResult {
@@ -442,7 +481,10 @@ interface DockerContainerWaitResult {
 
 interface DockerModemOperations {
   demuxStream(stream: NodeJS.ReadableStream, stdout: NodeJS.WritableStream, stderr: NodeJS.WritableStream): void;
-  followProgress(stream: NodeJS.ReadableStream, completed: (error: Error | null) => void): void;
+  followProgress(
+    stream: NodeJS.ReadableStream,
+    completed: (error: Error | null, output: readonly unknown[]) => void,
+  ): void;
 }
 
 function dockerModem(docker: Docker): DockerModemOperations {
@@ -507,6 +549,56 @@ function normalizeDockerImageReference(reference: string): string {
       ? `docker.io/library/${name}`
       : `docker.io/${name}`;
   return `${normalizedName}${suffix}`;
+}
+
+function dockerImageIds(images: readonly DockerImageSummary[]): Set<string> {
+  return new Set(images.flatMap((image) => (image.Id ? [image.Id] : [])));
+}
+
+function findDockerImageIdsByReferences(
+  images: readonly DockerImageSummary[],
+  references: readonly string[],
+): Set<string> {
+  const expected = new Set(references.map(normalizeDockerImageReference));
+  return new Set(
+    images.flatMap((image) => {
+      if (!image.Id) return [];
+      const matches = [...(image.RepoTags ?? []), ...(image.RepoDigests ?? [])].some((reference) =>
+        expected.has(normalizeDockerImageReference(reference)),
+      );
+      return matches ? [image.Id] : [];
+    }),
+  );
+}
+
+function readDockerImageLoadIdentity(events: readonly unknown[]): {
+  imageIds: ReadonlySet<string>;
+  references: ReadonlySet<string>;
+} {
+  const imageIds = new Set<string>();
+  const references = new Set<string>();
+  for (const event of events) {
+    if (!isRecord(event)) continue;
+    for (const value of [event.stream, event.status]) {
+      if (typeof value !== "string") continue;
+      for (const line of value.split(/\r?\n/u)) {
+        const imageId = /^Loaded image ID:\s*(sha256:[a-f0-9]{64})\s*$/iu.exec(line)?.[1];
+        if (imageId) {
+          imageIds.add(imageId.toLowerCase());
+          continue;
+        }
+        const reference = /^Loaded image:\s*(\S+)\s*$/u.exec(line)?.[1];
+        if (reference) references.add(reference);
+      }
+    }
+  }
+  return { imageIds, references };
+}
+
+function firstSetValue(values: ReadonlySet<string>): string {
+  const value = values.values().next().value;
+  if (typeof value !== "string") throw new Error("Expected a non-empty Docker image identity set.");
+  return value;
 }
 
 function imageNameWithoutTag(reference: string): string {

--- a/Source/AgentSystem/Sandbox/Gvisor/AgentGvisorWorkerClient.ts
+++ b/Source/AgentSystem/Sandbox/Gvisor/AgentGvisorWorkerClient.ts
@@ -134,7 +134,8 @@ export class AgentGvisorWorkerSocketClient implements SeneraGvisorWorkerClient {
             for (const value of decoder.push(Buffer.from(chunk))) {
               const message = AgentGvisorWorkerServerMessageSchema.parse(value);
               if (message.type === "progress") {
-                onProgress?.({ stage: message.stage, item: message.item });
+                const { type: _type, ...progress } = message;
+                onProgress?.(progress);
               } else if (message.type === "error") {
                 reject(workerError(message));
               } else {

--- a/Source/AgentSystem/Sandbox/Gvisor/AgentGvisorWorkerProtocol.ts
+++ b/Source/AgentSystem/Sandbox/Gvisor/AgentGvisorWorkerProtocol.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { AgentSandboxPreparationStages } from "../AgentSandboxRuntimeTypes.js";
 import { readAgentGvisorRuntimePolicyContract } from "./AgentGvisorRuntimeContract.js";
 
 export const AgentGvisorWorkerProtocolVersion = 1;
@@ -8,6 +9,8 @@ export const AgentGvisorWorkerMaxFrameBytes = RuntimePolicy.protocol.maxFrameByt
 const NonEmptyString = z.string().trim().min(1);
 const AbsoluteGuestPath = z.string().startsWith("/").min(1);
 const InitialMessage = z.object({ protocolVersion: z.literal(AgentGvisorWorkerProtocolVersion) });
+const PreparationStage = z.enum(Object.values(AgentSandboxPreparationStages));
+const ProgressCount = z.number().int().nonnegative();
 
 export const AgentGvisorExecutionRequestSchema = z
   .object({
@@ -105,17 +108,12 @@ export const AgentGvisorWorkerServerMessageSchema = z.discriminatedUnion("type",
   z
     .object({
       type: z.literal("progress"),
-      stage: z.enum([
-        "checking_host_runtime",
-        "connecting_worker",
-        "loading_runtime",
-        "resolving_archive",
-        "verifying_archive",
-        "importing_image",
-        "warming_image",
-        "probing_sandbox",
-      ]),
+      stage: PreparationStage,
       item: z.string().optional(),
+      completed: ProgressCount.optional(),
+      total: ProgressCount.optional(),
+      downloadedBytes: ProgressCount.optional(),
+      totalBytes: ProgressCount.optional(),
     })
     .strict(),
   z.object({ type: z.literal("prepared") }).strict(),

--- a/Source/AgentSystem/Sandbox/Gvisor/AgentGvisorWorkerServer.ts
+++ b/Source/AgentSystem/Sandbox/Gvisor/AgentGvisorWorkerServer.ts
@@ -96,8 +96,7 @@ export class AgentGvisorWorkerServer {
         onProgress: (progress) => {
           void writeFrame(socket, {
             type: "progress",
-            stage: progress.stage,
-            ...(progress.item ? { item: progress.item } : {}),
+            ...progress,
           }).catch(() => undefined);
         },
       })


### PR DESCRIPTION
## Summary

- project a standalone, microsandbox-only Nano development runtime
- resolve verified OCI Bundle imports across Docker Engine image-store variants
- preserve byte-level sandbox preparation progress across the gVisor worker protocol

## Verification

- `npm run test.backend` (705 tests)
- `npm run check.types`
- `npm run quality.lint`
- `npm run quality.format`
- `npm run build`
- `node Dist/Scripts/VerifySuite.js workspace core platform release` (63 scripts)
- real Docker Engine import of `SeneraSandboxImage-1.0.2-x64.oci.tar.gz`