### PR TITLE
fix(docker): distribute sandbox runtime through registry

### DIFF
--- a/Scripts/BackendTests/Execution/DockerImageLoadIdentityBehavior.test.ts
+++ b/Scripts/BackendTests/Execution/DockerImageLoadIdentityBehavior.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { resolveAgentDockerLoadedImageId } from "../../../Source/AgentSystem/Sandbox/DockerEngine/AgentDockerImageLoadIdentity.js";
+
+const ConfigDigest = `sha256:${"a".repeat(64)}`;
+const ManifestDigest = `sha256:${"b".repeat(64)}`;
+const SourceReference = `docker.io/library/node@sha256:${"c".repeat(64)}`;
+
+describe("Docker image load identity", () => {
+  test("uses the OCI config digest exposed by Docker's classic image store", () => {
+    expect(
+      resolveAgentDockerLoadedImageId({
+        imagesBefore: [{ Id: ConfigDigest }],
+        imagesAfter: [{ Id: ConfigDigest }],
+        loadEvents: [],
+        expectedImageIds: [ConfigDigest],
+        expectedReferences: [SourceReference],
+      }),
+    ).toBe(ConfigDigest);
+  });
+
+  test("uses Docker Hub's normalized reference from a containerd image store", () => {
+    expect(
+      resolveAgentDockerLoadedImageId({
+        imagesBefore: [],
+        imagesAfter: [
+          { Id: ManifestDigest, RepoTags: [SourceReference.replace("docker.io/library/", "")], RepoDigests: [] },
+        ],
+        loadEvents: [],
+        expectedImageIds: [ConfigDigest],
+        expectedReferences: [SourceReference],
+      }),
+    ).toBe(ManifestDigest);
+  });
+
+  test("uses Docker's load response for an already-present dangling image", () => {
+    const danglingImage = { Id: ManifestDigest, RepoTags: ["<none>:<none>"], RepoDigests: [] };
+    expect(
+      resolveAgentDockerLoadedImageId({
+        imagesBefore: [danglingImage],
+        imagesAfter: [danglingImage],
+        loadEvents: [{ stream: `Loaded image ID: ${ManifestDigest}\n` }],
+        expectedImageIds: [ConfigDigest],
+        expectedReferences: [SourceReference],
+      }),
+    ).toBe(ManifestDigest);
+  });
+
+  test("uses a unique image inventory delta when Docker omits load identity", () => {
+    expect(
+      resolveAgentDockerLoadedImageId({
+        imagesBefore: [{ Id: "sha256:existing" }],
+        imagesAfter: [{ Id: "sha256:existing" }, { Id: ManifestDigest }],
+        loadEvents: [],
+        expectedImageIds: [ConfigDigest],
+        expectedReferences: [SourceReference],
+      }),
+    ).toBe(ManifestDigest);
+  });
+
+  test("rejects conflicting identities instead of tagging an ambiguous image", () => {
+    expect(() =>
+      resolveAgentDockerLoadedImageId({
+        imagesBefore: [],
+        imagesAfter: [{ Id: ConfigDigest }, { Id: ManifestDigest, RepoTags: [SourceReference] }],
+        loadEvents: [],
+        expectedImageIds: [ConfigDigest],
+        expectedReferences: [SourceReference],
+      }),
+    ).toThrow("identified multiple images");
+  });
+});

--- a/Scripts/BackendTests/Execution/GvisorDockerEngineRuntimeBehavior.test.ts
+++ b/Scripts/BackendTests/Execution/GvisorDockerEngineRuntimeBehavior.test.ts
@@ -91,6 +91,7 @@ describe("Docker Engine sandbox runtime", () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "senera-docker-bundle-identity-"));
     const archivePath = path.join(root, "runtime.oci.tar.gz");
     const resolved = readAgentDockerEngineRuntimeContract("docker-engine", "x64");
+    const importedImageId = `sha256:${"d".repeat(64)}`;
     const tag = vi.fn(async () => undefined);
     const createContainer = vi.fn(async () => ({
       start: vi.fn(async () => undefined),
@@ -103,11 +104,15 @@ describe("Docker Engine sandbox runtime", () => {
       info: vi.fn(async () => ({ Runtimes: { runc: {} } })),
       getImage: vi.fn((reference: string) => {
         if (reference === resolved.image.runtimeImage) return { inspect: vi.fn(async () => Promise.reject(missing)) };
-        if (reference === resolved.image.sourceImage) {
-          return { inspect: vi.fn(async () => ({ Id: `sha256:${"d".repeat(64)}` })), tag };
-        }
+        if (reference === importedImageId) return { tag };
         throw new Error(`Unexpected image reference: ${reference}`);
       }),
+      listImages: vi
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          { Id: importedImageId, RepoTags: [resolved.image.sourceImage.replace("docker.io/library/", "")] },
+        ]),
       loadImage: vi.fn(async (archive: NodeJS.ReadableStream) => {
         for await (const _chunk of archive as NodeJS.ReadableStream & AsyncIterable<Buffer>) {
           // Consume the verified archive exactly as the Docker Engine API does.
@@ -116,7 +121,13 @@ describe("Docker Engine sandbox runtime", () => {
       }),
       createContainer,
       modem: {
-        followProgress: (_stream: NodeJS.ReadableStream, callback: (error: Error | null) => void) => callback(null),
+        followProgress: (
+          _stream: NodeJS.ReadableStream,
+          callback: (error: Error | null, output: readonly unknown[]) => void,
+        ) =>
+          callback(null, [
+            { stream: `Loaded image: ${resolved.image.sourceImage.replace("docker.io/library/", "")}\n` },
+          ]),
       },
     } as unknown as Docker;
     await writeFile(archivePath, gzipSync(Buffer.from("verified OCI archive")));

--- a/Source/AgentSystem/Sandbox/DockerEngine/AgentDockerImageLoadIdentity.ts
+++ b/Source/AgentSystem/Sandbox/DockerEngine/AgentDockerImageLoadIdentity.ts
@@ -1,0 +1,132 @@
+export interface AgentDockerImageSummary {
+  Id?: string;
+  RepoTags?: string[];
+  RepoDigests?: string[];
+}
+
+export interface AgentDockerImageLoadResolutionInput {
+  imagesBefore: readonly AgentDockerImageSummary[];
+  imagesAfter: readonly AgentDockerImageSummary[];
+  loadEvents: readonly unknown[];
+  expectedImageIds: readonly string[];
+  expectedReferences: readonly string[];
+}
+
+/** Resolves exactly one image from Docker's load result and post-load inventory. */
+export function resolveAgentDockerLoadedImageId(input: AgentDockerImageLoadResolutionInput): string {
+  const beforeIds = dockerImageIds(input.imagesBefore);
+  const afterIds = dockerImageIds(input.imagesAfter);
+  const identifiedIds = new Set<string>();
+
+  for (const expectedId of input.expectedImageIds.map(normalizeDockerImageId)) {
+    if (afterIds.has(expectedId)) identifiedIds.add(expectedId);
+  }
+  addSetValues(identifiedIds, findDockerImageIdsByReferences(input.imagesAfter, input.expectedReferences));
+
+  const loadIdentity = readDockerImageLoadIdentity(input.loadEvents);
+  for (const imageId of loadIdentity.imageIds) {
+    if (!afterIds.has(imageId)) {
+      throw new Error(`Docker reported loaded image ${imageId}, but it is absent from the post-import inventory.`);
+    }
+    identifiedIds.add(imageId);
+  }
+  addSetValues(identifiedIds, findDockerImageIdsByReferences(input.imagesAfter, [...loadIdentity.references]));
+
+  if (identifiedIds.size === 1) return firstSetValue(identifiedIds);
+  if (identifiedIds.size > 1) {
+    throw new Error(
+      `Verified Sandbox Bundle load identified multiple images: ${[...identifiedIds].sort().join(", ")}.`,
+    );
+  }
+
+  const addedIds = new Set([...afterIds].filter((imageId) => !beforeIds.has(imageId)));
+  if (addedIds.size === 1) return firstSetValue(addedIds);
+  throw new Error(
+    addedIds.size === 0
+      ? "Verified Sandbox Bundle was loaded, but Docker did not expose its image identity."
+      : `Verified Sandbox Bundle load added multiple images: ${[...addedIds].sort().join(", ")}.`,
+  );
+}
+
+function dockerImageIds(images: readonly AgentDockerImageSummary[]): Set<string> {
+  return new Set(images.flatMap((image) => (image.Id ? [normalizeDockerImageId(image.Id)] : [])));
+}
+
+function findDockerImageIdsByReferences(
+  images: readonly AgentDockerImageSummary[],
+  references: readonly string[],
+): Set<string> {
+  const expected = new Set(references.map(normalizeDockerImageReference));
+  return new Set(
+    images.flatMap((image) => {
+      if (!image.Id) return [];
+      const matches = [...(image.RepoTags ?? []), ...(image.RepoDigests ?? [])].some((reference) =>
+        expected.has(normalizeDockerImageReference(reference)),
+      );
+      return matches ? [normalizeDockerImageId(image.Id)] : [];
+    }),
+  );
+}
+
+function readDockerImageLoadIdentity(events: readonly unknown[]): {
+  imageIds: ReadonlySet<string>;
+  references: ReadonlySet<string>;
+} {
+  const imageIds = new Set<string>();
+  const references = new Set<string>();
+  for (const event of events) {
+    if (!isRecord(event)) continue;
+    for (const value of [event.stream, event.status]) {
+      if (typeof value !== "string") continue;
+      for (const line of value.split(/\r?\n/u)) {
+        const imageId = /^Loaded image ID:\s*(sha256:[a-f0-9]{64})\s*$/iu.exec(line)?.[1];
+        if (imageId) {
+          imageIds.add(normalizeDockerImageId(imageId));
+          continue;
+        }
+        const reference = /^Loaded image:\s*(\S+)\s*$/u.exec(line)?.[1];
+        if (reference) references.add(reference);
+      }
+    }
+  }
+  return { imageIds, references };
+}
+
+function normalizeDockerImageId(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeDockerImageReference(reference: string): string {
+  const trimmed = reference.trim();
+  const digestSeparator = trimmed.indexOf("@");
+  const name = digestSeparator >= 0 ? trimmed.slice(0, digestSeparator) : imageNameWithoutTag(trimmed);
+  const suffix = digestSeparator >= 0 ? trimmed.slice(digestSeparator) : trimmed.slice(name.length);
+  const segments = name.split("/");
+  const registry = segments[0] ?? "";
+  const hasExplicitRegistry = registry === "localhost" || registry.includes(".") || registry.includes(":");
+  const normalizedName = hasExplicitRegistry
+    ? `${registry === "index.docker.io" ? "docker.io" : registry}/${segments.slice(1).join("/")}`
+    : segments.length === 1
+      ? `docker.io/library/${name}`
+      : `docker.io/${name}`;
+  return `${normalizedName}${suffix}`;
+}
+
+function imageNameWithoutTag(reference: string): string {
+  const separator = reference.lastIndexOf(":");
+  return separator > reference.lastIndexOf("/") ? reference.slice(0, separator) : reference;
+}
+
+function addSetValues(target: Set<string>, values: ReadonlySet<string>): void {
+  for (const value of values) target.add(value);
+}
+
+function firstSetValue(values: ReadonlySet<string>): string {
+  const value = values.values().next().value;
+  if (typeof value !== "string") throw new Error("Expected a non-empty Docker image identity set.");
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/Source/AgentSystem/Sandbox/Gvisor/AgentGvisorDockerRuntime.ts
+++ b/Source/AgentSystem/Sandbox/Gvisor/AgentGvisorDockerRuntime.ts
@@ -20,6 +20,10 @@ import { AgentSandboxPreparationStages, type AgentSandboxPreparationProgress } f
 import { selectAgentSandboxProvider } from "../AgentSandboxProviderSelection.js";
 import { AgentSandboxRuntimeProviders } from "../AgentSandboxRuntimeTypes.js";
 import type { AgentSandboxProviderPreference } from "../../Types/AgentRuntimeConfigTypes.js";
+import {
+  resolveAgentDockerLoadedImageId,
+  type AgentDockerImageSummary,
+} from "../DockerEngine/AgentDockerImageLoadIdentity.js";
 
 export type AgentGvisorWorkspaceSource = { kind: "bind"; sourcePath: string } | { kind: "volume"; volumeName: string };
 
@@ -375,22 +379,31 @@ export class AgentGvisorDockerEngineRuntime implements AgentGvisorDockerRuntime 
       stage: AgentSandboxPreparationStages.ImportingImage,
       item: verified.manifest.runtimeImage,
     });
+    const imagesBefore = await this.listImages();
     const archive = createReadStream(verified.archivePath).pipe(createGunzip());
     const stream = await this.options.docker.loadImage(archive);
-    await new Promise<void>((resolve, reject) => {
-      dockerModem(this.options.docker).followProgress(stream, (error) => {
+    const loadEvents = await new Promise<readonly unknown[]>((resolve, reject) => {
+      dockerModem(this.options.docker).followProgress(stream, (error, output) => {
         if (error) reject(dockerOperationError("load bundled image", error));
-        else resolve();
+        else resolve(output);
       });
     });
     const target = splitImageReference(this.resolvedContract.image.runtimeImage);
-    const importedImage = this.options.docker.getImage(verified.manifest.sourceImage);
-    await importedImage
-      .inspect()
-      .catch((error: unknown) => Promise.reject(dockerOperationError("inspect bundled image", error)));
-    // Docker's classic and containerd image stores expose different values as
-    // ImageInspect.Id. The verified OCI source reference is stable across both.
+    const imagesAfter = await this.listImages();
+    const importedImage = this.options.docker.getImage(
+      resolveAgentDockerLoadedImageId({
+        imagesBefore,
+        imagesAfter,
+        loadEvents,
+        expectedImageIds: [verified.manifest.configDigest],
+        expectedReferences: [verified.manifest.runtimeImage, verified.manifest.sourceImage],
+      }),
+    );
     await importedImage.tag(target);
+  }
+
+  private async listImages(): Promise<readonly AgentDockerImageSummary[]> {
+    return (await this.options.docker.listImages({ all: true })) as AgentDockerImageSummary[];
   }
 
   private async stageRootfsCopies(copies: AgentGvisorExecutionRequest["rootfsCopies"]): Promise<string> {


### PR DESCRIPTION
## Summary

- Resolve verified OCI imports across classic Docker and containerd image stores.
- Correlate Bundle content identity, normalized references, Docker load results, and image inventory without assuming one universal image ID.
- Reject missing or ambiguous import identities before applying the Senera runtime tag.
- Add focused regression coverage for all supported Docker Engine identity shapes.

## Verification

- `npm run ci`
- Real Docker Desktop/containerd OCI Bundle import, runtime tagging, and sandbox probe