### PR TITLE
fix(docker): create runtime data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,14 +43,14 @@ ENV SENERA_SERVER_PORT=8787
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/Dist ./Dist
-COPY --from=builder /app/Frontend/dist ./Frontend/dist
+COPY --from=builder --chown=node:node /app/Frontend/dist ./Frontend/dist
 COPY --from=builder /app/McpServers ./McpServers
 COPY --from=builder /app/System ./System
 COPY --from=builder /app/Packages ./Packages
 COPY --from=builder /app/senera.config.example.json ./senera.config.example.json
 COPY --chmod=755 Apps/DockerEntrypoint.sh /usr/local/bin/senera-container-entrypoint
 
-RUN chown -R node:node /data /app/Frontend/dist
+RUN install -d -o node -g node /data
 
 VOLUME ["/data"]
 EXPOSE 8787

--- a/Scripts/VerifyDockerRuntimeSandboxPolicy.ts
+++ b/Scripts/VerifyDockerRuntimeSandboxPolicy.ts
@@ -102,6 +102,13 @@ assert.ok(
   "Docker must enter through the audited root bootstrap instead of running the application directly as root or node.",
 );
 assert.ok(
+  dockerfile.includes("COPY --from=builder --chown=node:node /app/Frontend/dist ./Frontend/dist") &&
+    dockerfile.includes("RUN install -d -o node -g node /data") &&
+    dockerfile.indexOf("RUN install -d -o node -g node /data") < dockerfile.indexOf('VOLUME ["/data"]') &&
+    !dockerfile.includes("chown -R node:node /data"),
+  "Docker runtime must create the managed data root before declaring its volume and assign copied assets directly.",
+);
+assert.ok(
   dockerfile.includes("HEALTHCHECK") && dockerfile.includes("setpriv --reuid=node --regid=node --clear-groups -- node"),
   "Docker health checks must run with the unprivileged application identity.",
 );


### PR DESCRIPTION
## 概要

- 在声明 `/data` volume 前显式创建运行时数据目录，并直接设置为 `node:node`
- 在复制前端产物时通过 `COPY --chown` 设置所有权，移除会因目录不存在而失败的递归 `chown`
- 扩展 Docker runtime policy，防止目录初始化顺序和所有权策略回退

## 根因

runtime stage 在 `/data` 尚不存在时执行 `chown -R node:node /data /app/Frontend/dist`，导致 Buildx 在最后一层以 `chown: cannot access '/data'` 退出。

## 验证

- `docker buildx build --pull --load --file Dockerfile .`
- 使用正式 sandbox runtime 和独立干净卷启动完整 `compose.yaml`：主服务与 worker 均为 healthy，`/health/ready` 返回 200，PID 1 以 UID/GID 1000 运行
- `npm run build`
- `npm run test.backend`：1171 passed
- `npm run test.integration`：17 passed
- `npm run verify.suite -- workspace core integration e2e release`：44 scripts passed
- `npm run quality.security`：0 vulnerabilities
- `npm run quality.coverage.ratchet`
- `npm run quality.format`
- `npm run quality.lint`