### PR TITLE
fix: 稳定 Nano 与 Chromium 验证

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -134,7 +134,9 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-${{ steps.playwright.outputs.version }}
-      - run: npx playwright install --with-deps chromium
+      - name: Install cached Chromium
+        run: npm run test.e2e.web.setup
+        timeout-minutes: 8
       - run: npm run test.e2e.web
       - name: Upload browser diagnostics
         if: failure()

--- a/Build/Distributions/NanoDistribution.json
+++ b/Build/Distributions/NanoDistribution.json
@@ -71,6 +71,7 @@
         "@types/react-dom",
         "@types/tar-fs",
         "@types/tar-stream",
+        "@types/turndown",
         "@types/ws",
         "@tailwindcss/vite",
         "@vitejs/plugin-react",

--- a/Scripts/VerifyBrowserE2eContracts.ts
+++ b/Scripts/VerifyBrowserE2eContracts.ts
@@ -35,6 +35,18 @@ assert.ok(
   ),
   "Chromium Browser E2E must resolve the Playwright cache version without nested shell command quoting.",
 );
+assert.ok(
+  verifyWorkflowSource.includes("run: npm run test.e2e.web.setup"),
+  "Chromium Browser E2E must reuse the cached Chromium installation script.",
+);
+assert.ok(
+  !verifyWorkflowSource.includes("playwright install --with-deps"),
+  "Chromium Browser E2E must not invoke APT system dependency installation on hosted runners.",
+);
+assert.ok(
+  verifyWorkflowSource.includes("timeout-minutes: 8"),
+  "Chromium Browser E2E browser installation must have a bounded timeout.",
+);
 
 let caseCount = 0;
 let browserTestSource = "";


### PR DESCRIPTION
## Summary
- 补齐 Nano 分发的 Turndown 类型依赖。
- 使用缓存 Chromium 安装，移除不稳定的 APT 系统依赖步骤。

## Verification
- npm run build
- npm run test.e2e.web.setup
- npm run verify.suite -- workspace e2e