### PR TITLE
fix(runtime): upgrade native SQLite for Node 24

### DIFF
--- a/Build/ElectronAfterPack.cjs
+++ b/Build/ElectronAfterPack.cjs
@@ -2,7 +2,11 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const NativeModules = {
-  "better-sqlite3": "better_sqlite3.node",
+  "better-sqlite3": (platform, architecture) => [
+    `prebuilds/${platform}-${architecture}.node`,
+    ...(platform === "linux" ? [`prebuilds/linuxmusl-${architecture}.node`] : []),
+    "build/Release/better_sqlite3.node",
+  ],
 };
 
 module.exports = async function injectStagedElectronNativeModules(context) {
@@ -15,19 +19,23 @@ module.exports = async function injectStagedElectronNativeModules(context) {
     `electron-${electronVersion}-${process.arch}`,
   );
 
-  for (const [moduleName, binaryName] of Object.entries(NativeModules)) {
-    const source = path.join(stageRoot, "node_modules", moduleName, "build", "Release", binaryName);
+  for (const [moduleName, artifactPaths] of Object.entries(NativeModules)) {
+    const moduleRoot = path.join(stageRoot, "node_modules", moduleName);
+    const artifactPath = artifactPaths(process.platform, process.arch).find((candidate) =>
+      fs.existsSync(path.join(moduleRoot, candidate)),
+    );
+    if (!artifactPath) {
+      throw new Error(`Staged Electron native module is missing: ${moduleRoot}`);
+    }
+    const source = path.join(moduleRoot, artifactPath);
     const target = path.join(
       context.appOutDir,
       "resources",
       "app.asar.unpacked",
       "node_modules",
       moduleName,
-      "build",
-      "Release",
-      binaryName,
+      artifactPath,
     );
-    if (!fs.existsSync(source)) throw new Error(`Staged Electron native module is missing: ${source}`);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.copyFileSync(source, target);
   }

--- a/Build/PrepareElectronNativeModules.ts
+++ b/Build/PrepareElectronNativeModules.ts
@@ -10,6 +10,18 @@ const { sync: spawnSync } = crossSpawn;
 
 export const ElectronNativeStageDirectory = path.join(".cache", "electron-native");
 export const ElectronNativeModuleNames = ["better-sqlite3"] as const;
+const NativeModuleArtifactPaths = {
+  "better-sqlite3": (platform: NodeJS.Platform, architecture: NodeJS.Architecture) => [
+    `prebuilds/${platform}-${architecture}.node`,
+    ...(platform === "linux" ? [`prebuilds/linuxmusl-${architecture}.node`] : []),
+    "build/Release/better_sqlite3.node",
+  ],
+} as const satisfies Record<(typeof ElectronNativeModuleNames)[number], NativeModuleArtifactPathResolver>;
+
+type NativeModuleArtifactPathResolver = (
+  platform: NodeJS.Platform,
+  architecture: NodeJS.Architecture,
+) => readonly string[];
 
 interface NativeStageManifest {
   fingerprint: string;
@@ -49,7 +61,7 @@ export async function prepareElectronNativeModules(workspaceRoot: string): Promi
     for (const moduleName of ElectronNativeModuleNames) {
       await copyNativeModuleSource(workspaceRoot, stagingRoot, moduleName);
     }
-    rebuildNativeModules(stagingRoot, electronVersion, process.arch);
+    rebuildNativeModules(stagingRoot, electronVersion, process.platform, process.arch);
     assertNativeStage(stagingRoot);
     await writeFile(
       path.join(stagingRoot, "manifest.json"),
@@ -82,13 +94,29 @@ export function resolveElectronNativeStageRoot(
   return path.join(workspaceRoot, ElectronNativeStageDirectory, `electron-${electronVersion}-${architecture}`);
 }
 
-function rebuildNativeModules(stagingRoot: string, electronVersion: string, architecture: NodeJS.Architecture): void {
+function rebuildNativeModules(
+  stagingRoot: string,
+  electronVersion: string,
+  platform: NodeJS.Platform,
+  architecture: NodeJS.Architecture,
+): void {
+  const modulesToRebuild = ElectronNativeModuleNames.filter(
+    (moduleName) =>
+      !hasNativeModuleArtifact(
+        path.join(stagingRoot, "node_modules", ...moduleName.split("/")),
+        moduleName,
+        platform,
+        architecture,
+      ),
+  );
+  if (modulesToRebuild.length === 0) return;
+
   const result = spawnSync(
     "electron-rebuild",
     [
       "--force",
       "--only",
-      ElectronNativeModuleNames.join(","),
+      modulesToRebuild.join(","),
       "--module-dir",
       stagingRoot,
       "--version",
@@ -155,17 +183,41 @@ function isCurrentStage(stageRoot: string, fingerprint: string): boolean {
 }
 
 function assertNativeStage(stageRoot: string): void {
-  const missing = ElectronNativeModuleNames.map((moduleName) =>
-    path.join(stageRoot, "node_modules", ...moduleName.split("/"), "build", "Release", nativeBinaryName(moduleName)),
-  ).filter((file) => !fs.existsSync(file));
+  const missing = ElectronNativeModuleNames.filter(
+    (moduleName) =>
+      !hasNativeModuleArtifact(
+        path.join(stageRoot, "node_modules", ...moduleName.split("/")),
+        moduleName,
+        process.platform,
+        process.arch,
+      ),
+  ).map((moduleName) =>
+    path.join(stageRoot, "node_modules", ...moduleName.split("/"), nativeModuleArtifactDescription(moduleName)),
+  );
   if (missing.length > 0) throw new Error(`Electron native module staging is incomplete: ${missing.join(", ")}`);
 }
 
-function nativeBinaryName(moduleName: (typeof ElectronNativeModuleNames)[number]): string {
-  const names = {
-    "better-sqlite3": "better_sqlite3.node",
-  } as const satisfies Record<(typeof ElectronNativeModuleNames)[number], string>;
-  return names[moduleName];
+export function nativeModuleArtifactRelativePaths(
+  moduleName: (typeof ElectronNativeModuleNames)[number],
+  platform: NodeJS.Platform = process.platform,
+  architecture: NodeJS.Architecture = process.arch,
+): readonly string[] {
+  return NativeModuleArtifactPaths[moduleName](platform, architecture);
+}
+
+function hasNativeModuleArtifact(
+  moduleRoot: string,
+  moduleName: (typeof ElectronNativeModuleNames)[number],
+  platform: NodeJS.Platform,
+  architecture: NodeJS.Architecture,
+): boolean {
+  return nativeModuleArtifactRelativePaths(moduleName, platform, architecture).some((relativePath) =>
+    fs.existsSync(path.join(moduleRoot, relativePath)),
+  );
+}
+
+function nativeModuleArtifactDescription(moduleName: (typeof ElectronNativeModuleNames)[number]): string {
+  return nativeModuleArtifactRelativePaths(moduleName).join(" or ");
 }
 
 function readPackageVersion(packageRoot: string): string {

--- a/Scripts/BackendTests/Core/PrepareElectronNativeModulesBehavior.test.ts
+++ b/Scripts/BackendTests/Core/PrepareElectronNativeModulesBehavior.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+import { nativeModuleArtifactRelativePaths } from "../../../Build/PrepareElectronNativeModules.js";
+
+describe("Electron native module preparation", () => {
+  test("prefers the N-API prebuild supplied by current better-sqlite3 releases", () => {
+    expect(nativeModuleArtifactRelativePaths("better-sqlite3", "win32", "x64")).toEqual([
+      "prebuilds/win32-x64.node",
+      "build/Release/better_sqlite3.node",
+    ]);
+  });
+
+  test("keeps the legacy node-gyp location as a fallback and supports Linux libc variants", () => {
+    expect(nativeModuleArtifactRelativePaths("better-sqlite3", "linux", "arm64")).toEqual([
+      "prebuilds/linux-arm64.node",
+      "prebuilds/linuxmusl-arm64.node",
+      "build/Release/better_sqlite3.node",
+    ]);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "ai": "^7.0.15",
         "ai-sdk-guardrails": "^6.0.1",
         "ajv": "^8.20.0",
-        "better-sqlite3": "^12.10.0",
+        "better-sqlite3": "^13.0.3",
         "brace-expansion": "5.0.9",
         "busboy": "^1.6.0",
         "chalk": "^4.1.2",
@@ -12677,15 +12677,15 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.11.1",
-      "hasInstallScript": true,
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "license": "MIT",
       "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
+        "node-addon-api": "^8.0.0"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+        "node": ">=22"
       }
     },
     "node_modules/bidi-js": {
@@ -12718,13 +12718,6 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -14188,6 +14181,7 @@
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -14220,13 +14214,6 @@
       "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -14384,6 +14371,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -15785,13 +15773,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -16098,10 +16079,6 @@
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.6",
@@ -16539,10 +16516,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "13.0.6",
@@ -17549,10 +17522,6 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
       "license": "ISC"
     },
     "node_modules/inline-style-parser": {
@@ -20262,6 +20231,7 @@
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20295,6 +20265,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -20587,10 +20558,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -20607,14 +20574,13 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-abi": {
-      "version": "3.92.0",
+    "node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
       "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/node-api-version": {
@@ -21687,58 +21653,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/tar-fs": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
-      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -22111,19 +22025,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
       }
     },
     "node_modules/react": {
@@ -22915,6 +22816,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -23326,47 +23228,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -23720,13 +23581,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/strnum": {
@@ -24455,16 +24309,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/turndown": {

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "ai": "^7.0.15",
     "ai-sdk-guardrails": "^6.0.1",
     "ajv": "^8.20.0",
-    "better-sqlite3": "^12.10.0",
+    "better-sqlite3": "^13.0.3",
     "brace-expansion": "5.0.9",
     "busboy": "^1.6.0",
     "chalk": "^4.1.2",


### PR DESCRIPTION
Upgrades better-sqlite3 to the Node 24 compatible release and adapts Electron packaging to its N-API platform prebuilds. Verified with the Node 24.19 Docker builder, packaged Windows SQLite smoke, Electron E2E, and a complete desktop installer build.